### PR TITLE
Fix regex errors, fix key name

### DIFF
--- a/default.py
+++ b/default.py
@@ -349,7 +349,7 @@ def get_sources(url, title, img, year, imdbnum, dialog):
         sorting = []
 
     container_pattern = r'<table[^>]+class="movie_version[ "][^>]*>(.*?)</table>'
-    item_pattern = re.compile(
+    item_pattern = (
                     r'quality_(?!sponsored|unknown)([^>]*)></span>.*?'
                     r'url=([^&]+)&(?:amp;)?domain=([^&]+)&(?:amp;)?(.*?)'
                     r'"version_veiws"> ([\d]+) views</')


### PR DESCRIPTION
Fix some regex errors of the form:

``` python
>>> import re
>>> x = re.compile( 'a' )
>>> y = re.finditer( x, '123abc', re.DOTALL )
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.6/re.py", line 186, in finditer
    return _compile(pattern, flags).finditer(string)
  File "/usr/lib/python2.6/re.py", line 238, in _compile
    raise ValueError('Cannot process flags argument with a compiled pattern')
ValueError: Cannot process flags argument with a compiled pattern
>>> 
```

Also fix a regex string that appears to have been half-way converted between: r'''123abc''' and r'123' r'abc'.

Finally, fix a dict key (local variable is named img, not image, assuming that is what the dict key should have been) that also caused a traceback.
