### PR TITLE
local_favs = cur.execute(sql).fetchall() causes crasch when table favori...

### DIFF
--- a/default.py
+++ b/default.py
@@ -1417,7 +1417,8 @@ def browse_favorites_website(section):
     else:
         db = orm.connect(DB_DIR)
     cur = db.cursor()
-    local_favs = cur.execute(sql).fetchall()
+    cur.execute(sql)
+    local_favs = cur.fetchall()
 
     if local_favs:
         _1CH.add_item({'mode': 'migrateFavs'}, {'title': 'Upload Local Favorites'})


### PR DESCRIPTION
local_favs = cur.execute(sql).fetchall() causes crasch when table favorites is empty and sql result is 0.

Error and solution is described here: http://stackoverflow.com/questions/13410982/attributeerror-long-object-has-no-attribute-fetchall
