### PR TITLE
Make Native Bookmarks work

### DIFF
--- a/default.py
+++ b/default.py
@@ -579,6 +579,7 @@ def PlaySource(url, title, img, year, imdbnum, video_type, season, episode, strm
     listitem = xbmcgui.ListItem(path=url, iconImage="DefaultVideo.png", thumbnailImage=poster)
 
     if (_1CH.get_setting('use-dialogs') == 'true'):
+        #print "Setting native resume: %s of %s" %(str(resume['position']),str(resume['total']))
         listitem.setProperty('ResumeTime', str(resume['position']))
         listitem.setProperty('TotalTime', str(resume['total']))
 

--- a/service.py
+++ b/service.py
@@ -98,8 +98,6 @@ class Service(xbmc.Player):
             self.tracking = True
             self.meta = json.loads(meta)
             self.video_type = 'tvshow' if 'episode' in self.meta else 'movie'
-            self._totalTime = self.getTotalTime()
-            #print "Total Time: %s"   % (str(self._totalTime))
             sql_stub = 'SELECT bookmark FROM bookmarks WHERE video_type=? AND title=?'
             if   self.video_type == 'tvshow': sql_stub += ' AND season=? AND episode=?'
             elif self.video_type == 'movie':  sql_stub += ' AND year=?'
@@ -130,6 +128,10 @@ class Service(xbmc.Player):
                     resume = resume.yesno(bmark_title, '', question, ln2, 'Start from beginning', 'Resume')
                     if resume: self.seekTime(bookmark)
                     self._sought = True
+
+            time.sleep(1)
+            self._totalTime = self.getTotalTime()
+            print "Total Time: %s"   % (str(self.getTotalTime()))
 
     def onPlayBackStopped(self):
         xbmc.log('PrimeWire: Playback Stopped')


### PR DESCRIPTION
Here's a fix to make native bookmarks work. I tested custom and native for episodes and they both work now. I haven't tested them with movies yet but they should be fixed too.

One persistent problem that I haven't quite figured out yet is that when re-resuming a previously resumed episode the new bookmark doesn't get saved and totalTime is 0 in onPlaybackStarted. That problem already existed in the old code but I haven't figured out what's causing it yet.
