### PR TITLE
Sometimes totalTime was still 0

### DIFF
--- a/service.py
+++ b/service.py
@@ -129,9 +129,12 @@ class Service(xbmc.Player):
                     if resume: self.seekTime(bookmark)
                     self._sought = True
 
-            time.sleep(1)
-            self._totalTime = self.getTotalTime()
-            print "Total Time: %s"   % (str(self.getTotalTime()))
+            self._totalTime=0
+            while self._totalTime == 0:
+                time.sleep(1)
+                self._totalTime = self.getTotalTime()
+                print "Total Time: %s"   % (self._totalTime)
+
 
     def onPlayBackStopped(self):
         xbmc.log('PrimeWire: Playback Stopped')


### PR DESCRIPTION
totalTime doesn't get set until the stream resolves which sometimes takes longer than 1 second so added a loop to catch that case. Resume won't work properly w/o totalTime being set. This could be why the guy on xbmchub was intermittently not getting working bookmarks.
