### PR TITLE
Add zero padding to episodes in utils.py

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -128,7 +128,9 @@ def format_tvshow_year(year):
 def format_tvshow_episode(info):
     episode_format = _1CH.get_setting('format-tvshow-episode')
     label = re.sub('\{s\}', str(info['season']), episode_format)
+    label = re.sub('\{0s\}', str(info['season']).zfill(2), episode_format)
     label = re.sub('\{e\}', str(info['episode']), label)
+    label = re.sub('\{0e\}', str(info['episode']).zfill(2), label)
     label = re.sub('\{t\}', info['title'], label)
     label = re.sub('\{st\}', info['TVShowTitle'], label)
     return label


### PR DESCRIPTION
Added option to zero-pad the episode and season numbers as `{0s}` and `{0e}`.

Personally I'm addicted to the S0xE0x formatting of episode labels so I wanted to have those options available.
